### PR TITLE
Fix formatting of the docker compose files, add quotes around vars

### DIFF
--- a/aurras-event-feed-substrate/docker-compose.yaml
+++ b/aurras-event-feed-substrate/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.8'
 services:
   aurras-event-feed-substrate:
     image: hugobyte/aurras-event-feed-substrate
@@ -15,9 +15,9 @@ services:
       - ./config:/config
 
 networks:
-    default:
-      name: aurras
-      driver: bridge
-    gateway:
-      name: gateway
-      external: true   
+  default:
+    name: aurras
+    driver: bridge
+  gateway:
+    name: gateway
+    external: true

--- a/openwhisk/docker-compose.yaml
+++ b/openwhisk/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.8'
 services:
   db:
     image: apache/couchdb:2.3
@@ -19,7 +19,7 @@ services:
     environment:
       ZOO_SERVERS: server.1=0.0.0.0:2888:3888
       ZOO_MY_ID: 1
-  
+
   kafka:
     image: wurstmeister/kafka:0.11.0.1
     networks:
@@ -56,16 +56,16 @@ services:
       - kafka
 
   kafka-topics-ui:
-      image: landoop/kafka-topics-ui:0.9.3
-      environment:
-        - KAFKA_REST_PROXY_URL=http://kafka-rest:8082
-        - KAFKA_REST_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
-        - PROXY=true
-      ports:
-        - 8001:8000
-      links:
-        - kafka
-        - kafka-rest
+    image: landoop/kafka-topics-ui:0.9.3
+    environment:
+      - KAFKA_REST_PROXY_URL=http://kafka-rest:8082
+      - KAFKA_REST_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
+      - PROXY=true
+    ports:
+      - 8001:8000
+    links:
+      - kafka
+      - kafka-rest
 
   redis:
     image: redis:2.8
@@ -80,7 +80,7 @@ services:
       - db:db.docker
     depends_on:
       - db
-    restart: "no"  
+    restart: "no"
     volumes:
       - ./logs:/logs
       - ./config/ansible:/openwhisk/ansible
@@ -148,7 +148,7 @@ services:
       - "31001:31001"
       - "9000:9000"
       - "9090:8080"
-  
+
   kafka-provider:
     image: openwhisk/kafkaprovider:nightly
     command: /bin/sh -c "cd KafkaFeedProvider && while ping -q -c1 db.setup >/dev/null; do sleep 1; done; python -u app.py >> /logs/kafka-provider.log 2>&1"
@@ -216,9 +216,9 @@ services:
       - "9333:9222"
 
 networks:
-    default:
-      name: openwhisk
-      driver: bridge
-    gateway:
-      name: gateway
-      driver: bridge  
+  default:
+    name: openwhisk
+    driver: bridge
+  gateway:
+    name: gateway
+    driver: bridge

--- a/openwhisk/docker-whisk-controller.env
+++ b/openwhisk/docker-whisk-controller.env
@@ -21,7 +21,7 @@ CONFIG_whisk_db_activationsFilterDdoc=whisks-filters.v2.1.0
 KAFKA_DEFAULT_REPLICATION_FACTOR=1
 KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
 KAFKA_BROKER_ID=0
-KAFKA_HEAP_OPTS=-Xmx512m -Xms512m
+KAFKA_HEAP_OPTS='-Xmx512m -Xms512m'
 KAFKA_ADVERTISED_PORT=9092
 KAFKA_TOPICS_COMPLETED_RETENTION_MS=300000
 KAFKA_TOPICS_COMPLETED_RETENTION_BYTES=104857600
@@ -42,7 +42,7 @@ CONFIG_whisk_containerPool_userMemory=1024m
 CONFIG_whisk_userEvents_enabled=true
 
 CONTROLLER_BLACKBOXFRACTION=0.10
-CONTROLLER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098 -Xdebug -Xrunjdwp:transport=dt_socket,address=9222,server=y,suspend=n
+CONTROLLER_OPTS='-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098 -Xdebug -Xrunjdwp:transport=dt_socket,address=9222,server=y,suspend=n'
 CONTROLLER_HA=false
 CONTROLLER_INSTANCES=1
 CONTROLLER_LOCALBOOKKEEPING=true
@@ -55,7 +55,7 @@ LOADBALANCER_ACTIVATIONCOUNTBEFORENEXTINVOKER=10
 LOADBALANCER_USERMEMORY=1024m
 
 CONFIG_whisk_docker_containerFactory_useRunc=false
-INVOKER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098 -Xdebug -Xrunjdwp:transport=dt_socket,address=9222,server=y,suspend=n
+INVOKER_OPTS='-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098 -Xdebug -Xrunjdwp:transport=dt_socket,address=9222,server=y,suspend=n'
 INVOKER_INSTANCES=3
 
 AKKA_CLUSTER_HOST=localhost


### PR DESCRIPTION
After updating the [docker engine](https://docs.docker.com/engine/release-notes/#20109) the .env file wouldn't be parsed due to whitespaces in some of the variables.